### PR TITLE
chore: add CI/CD workflows for build, scan, and release

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -1,0 +1,22 @@
+---
+name: Build, Push & Scan Container Image
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      go-version: "1.26.0"
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+---
+name: Release
+on:
+  workflow_run:
+    workflows: ["Build, Push & Scan Container Image"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-go-release.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      go-version: "1.26.0"
+      stage-image: true
+      push-kustomize: true
+      kcl-source-dir: kcl
+      kcl-profile-file: tests/kcl-deploy-profile.yaml
+      kustomize-oci-repo: ghcr.io/stuttgart-things/werunthings-kustomize
+    secrets: inherit # pragma: allowlist secret

--- a/tests/kcl-deploy-profile.yaml
+++ b/tests/kcl-deploy-profile.yaml
@@ -1,0 +1,5 @@
+---
+config.namespace: werunthings
+config.configName: portal-labul
+config.loadConfigFrom: cr
+config.configLocation: werunthings


### PR DESCRIPTION
## Summary
- Add `build-scan-image.yaml` — ko build + trivy scan on push/PR to main (same as clusterbook)
- Add `release.yaml` — semantic-release with KCL kustomize OCI push to `ghcr.io/stuttgart-things/werunthings-kustomize`
- Add `tests/kcl-deploy-profile.yaml` for release pipeline KCL rendering
- Skipped pages workflow (no mkdocs.yml in this repo)

## Test plan
- [ ] Push to main triggers build-scan-image workflow
- [ ] `feat:` commit triggers semantic-release via release workflow
- [ ] KCL profile renders correctly with `kcl run kcl/main.k --parameters-file tests/kcl-deploy-profile.yaml`

Generated with [Claude Code](https://claude.com/claude-code)