### PR TITLE
chore: rename module and resources to run-things

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,5 +26,5 @@ jobs:
       push-kustomize: true
       kcl-source-dir: kcl
       kcl-profile-file: tests/kcl-deploy-profile.yaml
-      kustomize-oci-repo: ghcr.io/stuttgart-things/werunthings-kustomize
+      kustomize-oci-repo: ghcr.io/stuttgart-things/run-things-kustomize
     secrets: inherit # pragma: allowlist secret

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,10 +1,10 @@
 ---
 defaultBaseImage: ghcr.io/stuttgart-things/sthings-alpine:1.23
 builds:
-  - id: weRunThings
+  - id: run-things
     dir: .
     main: main.go
     ldflags:
-      - -s -w -X github.com/stuttgart-things/weRunThings/internal.version={{.Env.VERSION}}
-      - -s -w -X github.com/stuttgart-things/weRunThings/internal.date={{.Env.BUILD_DATE}}
-      - -s -w -X github.com/stuttgart-things/weRunThings/internal.commit={{.Env.COMMIT}}
+      - -s -w -X github.com/stuttgart-things/run-things/internal.version={{.Env.VERSION}}
+      - -s -w -X github.com/stuttgart-things/run-things/internal.date={{.Env.BUILD_DATE}}
+      - -s -w -X github.com/stuttgart-things/run-things/internal.commit={{.Env.COMMIT}}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# weRunThings
+# run-things
 
 Service portal & health monitor for infrastructure services. Provides a real-time dashboard with health checks, TLS certificate monitoring, and cluster inventory tracking.
 
-<img src="https://raw.githubusercontent.com/stuttgart-things/docs/main/hugo/sthings-cinema%20wide.png" alt="weRunThings" width="200">
+<img src="https://raw.githubusercontent.com/stuttgart-things/docs/main/hugo/sthings-cinema%20wide.png" alt="run-things" width="200">
 
 ## Features
 
@@ -108,7 +108,7 @@ apiVersion: github.stuttgart-things.com/v1
 kind: ServicePortal
 metadata:
   name: portal-labul        # matches CONFIG_NAME
-  namespace: werunthings    # matches CONFIG_LOCATION
+  namespace: run-things    # matches CONFIG_LOCATION
 spec:
   services:
     - name: ArgoCD
@@ -165,9 +165,9 @@ task lint
 Version, commit, and build date are injected via ldflags:
 
 ```bash
-go install -ldflags="-X github.com/stuttgart-things/weRunThings/internal.version=v1.0.0 \
-  -X github.com/stuttgart-things/weRunThings/internal.date=$(date -Ih) \
-  -X github.com/stuttgart-things/weRunThings/internal.commit=$(git log -n1 --format=%h)"
+go install -ldflags="-X github.com/stuttgart-things/run-things/internal.version=v1.0.0 \
+  -X github.com/stuttgart-things/run-things/internal.date=$(date -Ih) \
+  -X github.com/stuttgart-things/run-things/internal.commit=$(git log -n1 --format=%h)"
 ```
 
 ## License

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -48,7 +48,7 @@ tasks:
       KO_DOCKER_REPO: ghcr.io/{{ .ORGA_NAME }}/{{ .PROJECT_NAME }}
     cmds:
       - |
-        BUILD_IMAGE=$(ko build {{ .MODULE }} --image-label org.opencontainers.image.source=https://github.com/stuttgart-things/weRunThings --push)
+        BUILD_IMAGE=$(ko build {{ .MODULE }} --image-label org.opencontainers.image.source=https://github.com/stuttgart-things/run-things --push)
         echo ${BUILD_IMAGE}
         dagger call -m github.com/jpadams/daggerverse/trivy@v0.3.0 scan-image --image-ref ${BUILD_IMAGE}
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stuttgart-things/weRunThings
+module github.com/stuttgart-things/run-things
 
 go 1.26.0
 

--- a/kcl/configmap.k
+++ b/kcl/configmap.k
@@ -1,5 +1,5 @@
 """
-ConfigMap for weRunThings
+ConfigMap for run-things
 """
 
 import labels

--- a/kcl/deploy.k
+++ b/kcl/deploy.k
@@ -1,5 +1,5 @@
 """
-Deployment for weRunThings
+Deployment for run-things
 """
 
 import labels

--- a/kcl/httproute.k
+++ b/kcl/httproute.k
@@ -1,5 +1,5 @@
 """
-HTTPRoute (Gateway API) for weRunThings frontend
+HTTPRoute (Gateway API) for run-things frontend
 """
 
 import labels

--- a/kcl/labels.k
+++ b/kcl/labels.k
@@ -1,5 +1,5 @@
 """
-Common labels and configuration for weRunThings resources
+Common labels and configuration for run-things resources
 """
 
 import schema
@@ -18,7 +18,7 @@ _httpRouteHostname = option("config.httpRouteHostname")
 _httpRouteAnnotations = option("config.httpRouteAnnotations") or {}
 
 # Config instance with command-line overrides
-config: schema.WeRunThings = schema.WeRunThings {
+config: schema.RunThings = schema.RunThings {
     if _image:
         image = _image
     if _namespace:
@@ -48,7 +48,7 @@ commonLabels = {
     "app.kubernetes.io/name": config.name
     "app.kubernetes.io/instance": config.name
     "app.kubernetes.io/component": "service-portal"
-    "app.kubernetes.io/part-of": "werunthings"
+    "app.kubernetes.io/part-of": "run-things"
     **config.labels
 }
 

--- a/kcl/main.k
+++ b/kcl/main.k
@@ -1,5 +1,5 @@
 """
-Main entry point for weRunThings Kubernetes deployment
+Main entry point for run-things Kubernetes deployment
 Imports all resources and exports manifests
 """
 

--- a/kcl/namespace.k
+++ b/kcl/namespace.k
@@ -1,5 +1,5 @@
 """
-Namespace for weRunThings
+Namespace for run-things
 """
 
 import labels

--- a/kcl/rbac.k
+++ b/kcl/rbac.k
@@ -1,5 +1,5 @@
 """
-RBAC resources for weRunThings (Role + RoleBinding for ServicePortal CRs)
+RBAC resources for run-things (Role + RoleBinding for ServicePortal CRs)
 """
 
 import labels

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -1,16 +1,16 @@
 """
-Schema definition for weRunThings deployment configuration
+Schema definition for run-things deployment configuration
 """
 
-schema WeRunThings:
-    """Configuration for weRunThings Kubernetes deployment"""
+schema RunThings:
+    """Configuration for run-things Kubernetes deployment"""
 
     # Metadata
-    name: str = "werunthings"
-    namespace: str = "werunthings"
+    name: str = "run-things"
+    namespace: str = "run-things"
 
     # Image
-    image: str = "ghcr.io/stuttgart-things/weRunThings:v0.1.0"
+    image: str = "ghcr.io/stuttgart-things/run-things:v0.1.0"
     imagePullPolicy: str = "Always"
 
     # Replicas and resources
@@ -28,7 +28,7 @@ schema WeRunThings:
 
     # Config
     loadConfigFrom: str = "cr"
-    configLocation: str = "werunthings"
+    configLocation: str = "run-things"
     configName: str = "portal-labul"
     serverPort: str = "50051"
 

--- a/kcl/service.k
+++ b/kcl/service.k
@@ -1,5 +1,5 @@
 """
-Services for weRunThings (gRPC + HTTP)
+Services for run-things (gRPC + HTTP)
 """
 
 import labels

--- a/kcl/serviceaccount.k
+++ b/kcl/serviceaccount.k
@@ -1,5 +1,5 @@
 """
-ServiceAccount for weRunThings
+ServiceAccount for run-things
 """
 
 import labels

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"os"
 
 	"github.com/pterm/pterm"
-	"github.com/stuttgart-things/weRunThings/internal"
+	"github.com/stuttgart-things/run-things/internal"
 
 	"google.golang.org/grpc"
 )

--- a/tests/crd.yaml
+++ b/tests/crd.yaml
@@ -2,7 +2,7 @@ apiVersion: github.stuttgart-things.com/v1
 kind: ServicePortal
 metadata:
   name: portal-labul
-  namespace: werunthings
+  namespace: run-things
 spec:
   services:
     - name: ArgoCD

--- a/tests/kcl-deploy-profile.yaml
+++ b/tests/kcl-deploy-profile.yaml
@@ -1,5 +1,5 @@
 ---
-config.namespace: werunthings
+config.namespace: run-things
 config.configName: portal-labul
 config.loadConfigFrom: cr
-config.configLocation: werunthings
+config.configLocation: run-things


### PR DESCRIPTION
## Summary
- Rename Go module from `github.com/stuttgart-things/weRunThings` to `github.com/stuttgart-things/run-things`
- Update all K8s resource names/namespaces from `werunthings` to `run-things`
- Update ko config, Taskfile, KCL manifests, tests, README, release workflow
- KCL schema renamed from `WeRunThings` to `RunThings`
- UI branding ("WE RUN THINGS") unchanged
- Fixes OCI registry build failure (uppercase letters not allowed)

## Test plan
- [x] `go build ./...` compiles
- [x] `kcl run kcl/main.k` renders correctly
- [ ] CI build-scan-image workflow succeeds with lowercase repo name

Generated with [Claude Code](https://claude.com/claude-code)