### PR TITLE
chore: add semantic-release config

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,40 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "angular"
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          "dist/**/*.{go,mod,sum}",
+          "docs/**/*.{pdf,md}"
+        ]
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "go.mod", "go.sum"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `.releaserc` config for semantic-release (same as clusterbook)
- Fixes release workflow failure caused by missing semantic-release config
- Enables automated versioning, changelog, and GitHub release creation

## Test plan
- [ ] Release workflow succeeds after merge (triggered by build-scan-image completion)

Generated with [Claude Code](https://claude.com/claude-code)