### PR TITLE
feat: add docs site, backstage config, and pages workflow

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,17 @@
+---
+name: Deploy Pages
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+jobs:
+  pages:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-deploy-pages.yaml@main
+    with:
+      runs-on: ubuntu-latest
+    secrets: inherit # pragma: allowlist secret

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: run-things
+  title: run-things
+  description: Service portal & health monitor for infrastructure services
+  annotations:
+    github.com/project-slug: stuttgart-things/run-things
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - go
+    - kubernetes
+    - health-monitoring
+    - service-portal
+    - htmx
+    - platform-engineering
+  links:
+    - url: https://stuttgart-things.github.io/run-things/
+      title: Documentation
+      icon: docs
+    - url: https://github.com/stuttgart-things/run-things/releases
+      title: Releases
+      icon: github
+spec:
+  type: service
+  lifecycle: production
+  owner: group:default/stuttgart-things
+  system: platform-engineering

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,61 @@
+# REST API
+
+## Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/services` | List all services |
+| `GET` | `/api/v1/services/{name}` | Get service details + health history |
+| `POST` | `/api/v1/services` | Add a service |
+| `DELETE` | `/api/v1/services/{name}` | Delete a service |
+| `GET` | `/api/v1/clusters` | List cluster inventory |
+| `GET` | `/api/v1/health` | Health probe |
+
+## Examples
+
+### List all services
+
+```bash
+curl http://localhost:8080/api/v1/services
+```
+
+### Add a service
+
+```bash
+curl -X POST http://localhost:8080/api/v1/services \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "ArgoCD",
+    "description": "GitOps CD tool",
+    "category": "CI/CD",
+    "url": "https://argocd.example.com",
+    "tags": ["gitops", "kubernetes"],
+    "healthCheck": {
+      "enabled": true,
+      "interval": 30,
+      "expectedStatus": 200,
+      "tlsCheck": true
+    }
+  }'
+```
+
+### Delete a service
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/services/ArgoCD
+```
+
+### Get service details
+
+```bash
+curl http://localhost:8080/api/v1/services/ArgoCD
+```
+
+Returns the service definition, current status, and health check history (last 60 results).
+
+### Health probe
+
+```bash
+curl http://localhost:8080/api/v1/health
+# {"status":"ok"}
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,99 @@
+# Configuration
+
+All configuration is via environment variables.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `LOAD_CONFIG_FROM` | `disk` | Config source: `disk` (YAML file) or `cr` (Kubernetes CRD) |
+| `CONFIG_LOCATION` | `tests` | Directory path for disk mode, namespace for CRD mode |
+| `CONFIG_NAME` | `services.yaml` | YAML filename or CRD resource name |
+| `HTTP_PORT` | `8080` | Web UI / REST API port |
+| `SERVER_PORT` | `50051` | gRPC server port |
+| `KUBECONFIG` | (K8s default) | Kubernetes config path (required for `cr` mode) |
+
+## Service Definition (YAML)
+
+```yaml
+services:
+  - name: ArgoCD
+    description: Declarative GitOps continuous delivery tool
+    category: CI/CD
+    url: https://argocd.example.com
+    logoURL: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
+    tags:
+      - gitops
+      - kubernetes
+    healthCheck:
+      enabled: true
+      interval: 30
+      method: GET
+      expectedStatus: 200
+      expectedBody: "ok"
+      tlsCheck: true
+      timeout: 10
+      headers:
+        Authorization: "Bearer token"
+      body: '{"key":"value"}'
+```
+
+### Service Fields
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | yes | Unique service identifier |
+| `description` | no | Human-readable description |
+| `category` | no | Grouping category (e.g. CI/CD, Monitoring) |
+| `url` | yes | Service URL to monitor |
+| `logoURL` | no | URL to service logo image |
+| `icon` | no | Unicode emoji fallback if no logo |
+| `tags` | no | Searchable tags |
+| `healthCheck` | no | Health check configuration |
+
+### Health Check Fields
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Enable health checking |
+| `interval` | `30` | Check interval in seconds |
+| `method` | `GET` | HTTP method |
+| `expectedStatus` | `200` | Expected HTTP status code |
+| `expectedBody` | — | Required text in response body |
+| `tlsCheck` | `false` | Check TLS certificate expiry |
+| `timeout` | `10` | Request timeout in seconds |
+| `headers` | — | Custom HTTP headers (map) |
+| `body` | — | Request body for POST/PUT |
+
+## Kubernetes CRD Mode
+
+Set `LOAD_CONFIG_FROM=cr` to read services from a Kubernetes Custom Resource:
+
+```yaml
+apiVersion: github.stuttgart-things.com/v1
+kind: ServicePortal
+metadata:
+  name: portal-labul
+  namespace: run-things
+spec:
+  services:
+    - name: ArgoCD
+      description: GitOps CD
+      category: CI/CD
+      url: https://argocd.example.com
+      healthCheck:
+        enabled: true
+        interval: 30
+        expectedStatus: 200
+        tlsCheck: true
+```
+
+## Example .env
+
+```bash
+LOAD_CONFIG_FROM=disk
+CONFIG_LOCATION=tests
+CONFIG_NAME=services.yaml
+SERVER_PORT=50051
+HTTP_PORT=8080
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,73 @@
+# Contributing
+
+## Development Setup
+
+```bash
+git clone https://github.com/stuttgart-things/run-things.git
+cd run-things
+go build ./...
+```
+
+Requires **Go 1.26+** and [Task](https://taskfile.dev).
+
+## Available Tasks
+
+| Task | Description |
+|---|---|
+| `task run-web` | Run web UI with disk config on :8080 |
+| `task build` | Lint + test + install |
+| `task test` | Run all tests |
+| `task lint` | Run golangci-lint |
+| `task build-ko` | Build + push + scan container image |
+
+## Running Tests
+
+```bash
+task test
+# or directly:
+go test ./... -v
+```
+
+## Project Structure
+
+```
+run-things/
+├── main.go              # Entry point: env wiring, gRPC + HTTP servers
+├── internal/
+│   ├── web.go           # HTTP/HTMX handlers, REST API, admin panel
+│   ├── models.go        # Service, HealthCheck, ClusterInfo types
+│   ├── monitor.go       # Health check scheduler + state management
+│   ├── load.go          # Config loading (disk YAML / K8s CRD)
+│   ├── save.go          # Config persistence (disk YAML / K8s CRD)
+│   ├── k8s.go           # Kubernetes dynamic client
+│   ├── tls.go           # TLS certificate checker
+│   ├── collector.go     # gRPC cluster collector
+│   └── version.go       # Banner + build info
+├── kcl/                 # KCL Kubernetes manifests
+├── tests/               # Test configs
+├── Taskfile.yaml        # Dev tasks
+└── .ko.yaml             # Ko build config
+```
+
+## Code Conventions
+
+- Logger: `pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)`
+- Env vars: read only in `main.go`, passed as constructor args
+- Config persistence: `SaveServices()` handles both disk and CRD backends
+- All HTMX handlers redirect to the originating page after mutations
+
+## PR Workflow
+
+1. Create a feature branch: `git checkout -b feat/my-feature`
+2. Implement + test
+3. `go build ./... && go test ./...`
+4. Push and open a PR targeting `main`
+5. CI runs build + scan automatically
+6. Semantic-release creates a version on merge (use conventional commits)
+
+## Commit Convention
+
+- `feat:` — new feature (minor version bump)
+- `fix:` — bug fix (patch version bump)
+- `chore:` — maintenance (no release)
+- `test:` — test additions (no release)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,67 @@
+# KCL Deployment
+
+run-things ships with [KCL](https://kcl-lang.io/) manifests (`kcl/`) for Kubernetes deployment.
+
+## Rendered Resources
+
+| Resource | Kind | Conditional |
+|---|---|---|
+| `run-things` | Namespace | Always |
+| `run-things` | ServiceAccount | Always |
+| `run-things-config` | ConfigMap | Always |
+| `run-things` | Role | Always |
+| `run-things` | RoleBinding | Always |
+| `run-things` | Deployment | Always |
+| `run-things` | Service (gRPC) | Always |
+| `run-things-http` | Service (HTTP) | Always |
+| `run-things` | HTTPRoute | Only if `httpRouteEnabled=true` |
+
+## Deploy
+
+```bash
+# Render and apply
+cd kcl && kcl run | kubectl apply -f -
+
+# With custom config
+kcl run -D 'config.image=ghcr.io/stuttgart-things/run-things:v0.1.0' \
+        -D 'config.namespace=run-things' \
+  | kubectl apply -f -
+
+# With HTTPRoute
+kcl run -D 'config.httpRouteEnabled=true' \
+        -D 'config.httpRouteParentRefName=my-gateway' \
+        -D 'config.httpRouteHostname=run-things.example.com' \
+  | kubectl apply -f -
+```
+
+## Configuration Reference
+
+| Parameter | Default | Description |
+|---|---|---|
+| `config.name` | `run-things` | Resource name |
+| `config.namespace` | `run-things` | Target namespace |
+| `config.image` | `ghcr.io/stuttgart-things/run-things:v0.1.0` | Container image |
+| `config.imagePullPolicy` | `Always` | Image pull policy |
+| `config.replicas` | `1` | Replica count |
+| `config.grpcPort` | `50051` | gRPC container port |
+| `config.httpPort` | `8080` | HTTP container port |
+| `config.loadConfigFrom` | `cr` | Config source: `disk` or `cr` |
+| `config.configLocation` | `run-things` | K8s namespace or file path |
+| `config.configName` | `portal-labul` | CRD resource name or filename |
+| `config.httpRouteEnabled` | `false` | Enable HTTPRoute (Gateway API) |
+| `config.httpRouteParentRefName` | — | Gateway name |
+| `config.httpRouteHostname` | — | Hostname for HTTPRoute |
+
+## Container Image
+
+Built with [ko](https://ko.build/) using a distroless base:
+
+```bash
+task build-ko
+```
+
+Image: `ghcr.io/stuttgart-things/run-things`
+
+## OCI Kustomize Artifact
+
+The release pipeline publishes a Kustomize OCI artifact to `ghcr.io/stuttgart-things/run-things-kustomize`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,46 @@
+# run-things
+
+**Service portal & health monitor for infrastructure services.**
+
+run-things provides a real-time dashboard with health checks, TLS certificate monitoring, and cluster inventory tracking — backed by Kubernetes CRDs or YAML files.
+
+## Features
+
+- **HTMX dashboard** — dark-themed service portal with live status updates
+- **Health checks** — HTTP probes with configurable intervals, expected status codes, and body matching
+- **TLS monitoring** — certificate expiry tracking with degraded status warnings
+- **Cluster inventory** — Kubernetes workload tracking via gRPC collectors
+- **REST API** — JSON endpoints for service CRUD and cluster data
+- **Admin panel** — inline editing, tags, add/delete services via web UI
+- **Dual storage** — YAML files (disk) or Kubernetes CRDs (ServicePortal)
+- **KCL deployment** — type-safe Kubernetes manifests
+
+## Quickstart
+
+```bash
+# Run locally with test config
+LOAD_CONFIG_FROM=disk CONFIG_LOCATION=tests CONFIG_NAME=services.yaml go run .
+
+# Or via Taskfile
+task run-web
+```
+
+Open [http://localhost:8080](http://localhost:8080)
+
+## Status Logic
+
+| Status | Condition |
+|---|---|
+| `UP` | Status code matches, body matches, response < 5s, TLS > 14 days |
+| `DEGRADED` | Slow response (> 5s) or TLS cert expiring within 14 days |
+| `DOWN` | Request failed or unexpected status code |
+
+## Task Shortcuts
+
+```bash
+task run-web                    # run with disk config on :8080
+task build                      # lint + test + install
+task test                       # go test ./...
+task lint                       # golangci-lint
+task build-ko                   # build + push container image
+```

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -1,0 +1,53 @@
+# Web UI
+
+The HTMX dashboard is available on port `:8080` (configurable via `HTTP_PORT`).
+
+## Routes
+
+| Path | Description |
+|---|---|
+| `/` | Dashboard — service cards with live health status |
+| `/service/{name}` | Service detail — health history timeline |
+| `/clusters` | Cluster inventory overview |
+| `/cluster/{name}` | Cluster detail — workloads, deployments, services |
+| `/admin` | Admin panel — add, edit, delete services |
+
+## Dashboard
+
+The main dashboard shows all services as cards grouped by category. Each card displays:
+
+- Service name, description, and logo/icon
+- Live health status dot (green/orange/red/grey)
+- Response time
+- Mini health timeline (last 60 checks)
+- Tags
+
+Cards auto-refresh health status via HTMX polling.
+
+## Admin Panel
+
+The admin panel (`/admin`) provides:
+
+### Add Service
+
+Fill in the form fields:
+
+- **Name** (required) — unique service identifier
+- **URL** (required) — endpoint to monitor
+- **Description** — human-readable description
+- **Category** — grouping (e.g. CI/CD, Monitoring)
+- **Logo URL** — service logo image URL
+- **Icon** — emoji fallback if no logo
+- **Tags** — comma-separated (e.g. `gitops, kubernetes`)
+- **Health Check** — enable HTTP health monitoring
+- **TLS Check** — monitor certificate expiry
+
+### Inline Edit
+
+Click **Edit** on any service row to expand an inline edit form with all fields pre-populated. Only one edit row can be open at a time. Click **Save** to persist or **Cancel** to discard.
+
+### Delete
+
+Click **Delete** on any service row (with confirmation prompt).
+
+All changes are persisted immediately to the configured backend (disk YAML or Kubernetes CRD).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,44 @@
+---
+site_name: run-things
+site_description: Service portal & health monitor for infrastructure services
+site_url: https://stuttgart-things.github.io/run-things/
+repo_url: https://github.com/stuttgart-things/run-things
+repo_name: stuttgart-things/run-things
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    scheme: slate
+    primary: deep orange
+    accent: amber
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
+    - search.highlight
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - attr_list
+
+nav:
+  - Home: index.md
+  - Usage:
+      - REST API: api.md
+      - Web UI: webui.md
+  - Configuration:
+      - Environment Variables: configuration.md
+      - KCL Deployment: deployment.md
+  - Contributing: contributing.md


### PR DESCRIPTION
## Summary
- Add MkDocs documentation site (Material theme, slate/deep-orange palette)
  - Home, REST API, Web UI, Configuration, KCL Deployment, Contributing
- Add GitHub Pages workflow (triggers after Release, uses shared template)
- Add Backstage `catalog-info.yaml` for service discovery

## Test plan
- [ ] `mkdocs serve` renders locally
- [ ] Pages workflow triggers after next release
- [ ] Backstage discovers the component via catalog-info.yaml

Generated with [Claude Code](https://claude.com/claude-code)